### PR TITLE
12 allow for interval value ranges

### DIFF
--- a/examples/example_with_ranges.cfg
+++ b/examples/example_with_ranges.cfg
@@ -1,0 +1,13 @@
+[DATABASE]
+provider=sqlite
+database=py_experimenter
+table=example_with_ranges
+
+[PY_EXPERIMENTER]
+cpu.max = 5
+
+keyfields = value:int, exponent:int
+resultfields = sin, cos
+
+value=1-4:1,6-14:2,3,7
+exponent=1-3

--- a/examples/example_with_ranges.cfg
+++ b/examples/example_with_ranges.cfg
@@ -9,5 +9,5 @@ cpu.max = 5
 keyfields = value:int, exponent:int
 resultfields = sin, cos
 
-value=1-4:1,6-14:2,3,7
-exponent=1-3
+value=1:4:1,6:14:2,3,7
+exponent=1:3

--- a/examples/example_with_ranges.py
+++ b/examples/example_with_ranges.py
@@ -1,0 +1,36 @@
+import logging
+from math import cos, sin
+import os
+
+from py_experimenter.experimenter import PyExperimenter
+from py_experimenter.result_processor import ResultProcessor
+
+
+def own_function(parameters: dict, result_processor: ResultProcessor, custom_config: dict):
+    # run the experiment with the given value for the sin and cos function
+    sin_result = sin(parameters['value'])**parameters['exponent']
+    cos_result = cos(parameters['value'])**parameters['exponent']
+
+    # write result in dict with the resultfield as key
+    result = {'sin': sin_result, 'cos': cos_result}
+
+    # send result to to the database
+    result_processor.process_results(result)
+
+
+logging.basicConfig(level=logging.INFO)
+
+# Create sqlite experimenter.
+experimenter = PyExperimenter(config_path=os.path.join('examples', 'example_with_ranges.cfg'))
+# To use a mysql database, modify the examples/example_fill_complex.cfg file and change the provider to mysql.
+# In addition you need to provide the credentials file config/database_credentials.cfg and confirm that you
+# have the permission to create a database/a database exists as defined in the config file.
+# For more information refer to the README.md file.
+
+
+
+# Fill database table with combination of values defined in the configuration.
+experimenter.fill_table_from_config()
+
+# Execute all experiments.
+experimenter.execute(own_function, -1)

--- a/examples/example_with_ranges.py
+++ b/examples/example_with_ranges.py
@@ -1,9 +1,11 @@
 import logging
-from math import cos, sin
 import os
+from math import cos, sin
 
 from py_experimenter.experimenter import PyExperimenter
 from py_experimenter.result_processor import ResultProcessor
+
+logging.basicConfig(level=logging.INFO)
 
 
 def own_function(parameters: dict, result_processor: ResultProcessor, custom_config: dict):
@@ -18,16 +20,12 @@ def own_function(parameters: dict, result_processor: ResultProcessor, custom_con
     result_processor.process_results(result)
 
 
-logging.basicConfig(level=logging.INFO)
-
 # Create sqlite experimenter.
 experimenter = PyExperimenter(config_path=os.path.join('examples', 'example_with_ranges.cfg'))
 # To use a mysql database, modify the examples/example_fill_complex.cfg file and change the provider to mysql.
 # In addition you need to provide the credentials file config/database_credentials.cfg and confirm that you
 # have the permission to create a database/a database exists as defined in the config file.
 # For more information refer to the README.md file.
-
-
 
 # Fill database table with combination of values defined in the configuration.
 experimenter.fill_table_from_config()

--- a/test/test_config_files/load_config_test_file/test_get_keyfield_data.cfg
+++ b/test/test_config_files/load_config_test_file/test_get_keyfield_data.cfg
@@ -1,0 +1,19 @@
+[DATABASE]
+provider=sqlite
+database=py_experimenter
+table=test_get_keyfield_data
+
+[PY_EXPERIMENTER]
+cpu.max = 5
+
+keyfields = value:int, value2:int(5), value3, value4:int,
+
+value = 1:5:1
+value2 = 1:5
+value3 = different,test,strings
+value4 = 1:5, 6:10:2, 5
+
+
+[CUSTOM]
+pause.max=10
+pause.threshold = 8


### PR DESCRIPTION
For clarity, we modified the syntax from
2-10:2 -> 2,4,6,8,10
to 
2:10:2 -> 2,4,6,8,10
since 
-1--3:2 -> -1,-3
is harder to read.

Additionally, there is a standard step size of 1.