### PR TITLE
Add test workflow based on GitHub Actions

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,44 @@
+name: Tests
+
+on: [push, pull_request]
+
+jobs:
+  tests:
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ "ubuntu-latest", "macos-latest", "windows-latest" ]
+        python-version: [ "3.7", "3.8", "3.9", ]
+    defaults:
+      run:
+        shell: bash
+    runs-on: ${{ matrix.os }}
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v3
+      - name: Set up Python ${{ matrix.python-version }}
+        id: setup-python
+        uses: actions/setup-python@v4
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Install Poetry
+        uses: snok/install-poetry@v1
+        with:
+          virtualenvs-create: true
+          virtualenvs-in-project: true
+      - name: Load cached venv
+        id: cached-poetry-dependencies
+        uses: actions/cache@v3
+        with:
+          path: .venv
+          key: venv-${{ runner.os }}-${{ steps.setup-python.outputs.python-version }}-${{ hashFiles('**/poetry.lock') }}
+      - name: Install dependencies
+        if: steps.cached-poetry-dependencies.outputs.cache-hit != 'true'
+        run: poetry install --no-interaction --no-root
+      - name: Install package
+        run: poetry install --no-interaction
+      - name: Run tests
+        run: |
+          source $VENV
+          # Ignore the MySQL test, as it requires a MySQL server:
+          pytest --ignore=test/test_run_experiments/test_run_mysql_experiment.py


### PR DESCRIPTION
Rationale
------------

After #54 added support for [poetry](https://python-poetry.org/docs/), it is straightforward to introduce a testing workflow based on GitHub Actions.

This can be used to implement:

- Running tests using `pytest` (done in this PR)
- Checking code formatting
- Linting the code
- Static type checking using [mypy](http://mypy-lang.org/)
- And much more …

Description
---------------

This pull request adds a simple test runner using GitHub Actions. It uses [poetry](https://python-poetry.org/docs/) to install the package and locked dependencies. 

In addition it implements the following functionality:

- Caching the virtual environment. This prevents having to install it everytime and cuts down on CI roundtrip times.
- It tests a matrix of various python versions (3.7, 3.8, 3.9) and OS versions (Ubuntu and MacOS). Python 3.10 is excluded for now, since installing some of the dependencies takes a very long time.

How has this PR been tested?
----------------------------------------

The workflow is running correctly on GitHub and all tests are passing.

What is missing?
-----------------------

The base branch for this pull request is #54. Thus we need to merge that one before merging this PR.

What should be reviewed?
-----------------------------------

- Should we also test windows?