### PR TITLE
Add command to fetch remote branches to how-to-contribute.rst

### DIFF
--- a/docs/source/how-to-contribute.rst
+++ b/docs/source/how-to-contribute.rst
@@ -59,6 +59,7 @@ The contribution workflow for the `PyExperimenter` is based on the fork-and-bran
    
    .. code-block:: 
 
+        git fetch --all
         git branch -v -a
         git switch develop
         git checkout -b <feature_branch_name>


### PR DESCRIPTION
I suggest adding a line to fetch from all remotes to the how-to-contribute so that they are available in the cloned repo.

This addresses #64.