### PR TITLE
Change row identification in ResultProcessor.

### DIFF
--- a/py_experimenter/experimenter.py
+++ b/py_experimenter/experimenter.py
@@ -387,14 +387,14 @@ class PyExperimenter:
         :raises NoExperimentsLeftError: If there are no experiments left to be executed.
         :raises DatabaseConnectionError: If an error occurred during the connection to the database.
         """
-        _, keyfield_values = self.dbconnector.get_experiment_configuration(random_order)
+        experiment_id, keyfield_values = self.dbconnector.get_experiment_configuration(random_order)
         
         result_field_names = utils.get_result_field_names(self.config)
         custom_fields = dict(self.config.items('CUSTOM')) if self.has_section('CUSTOM') else None
         table_name = self.get_config_value('PY_EXPERIMENTER', 'table')
 
         result_processor = ResultProcessor(self.config, self.database_credential_file_path, table_name=table_name,
-                                           condition=keyfield_values, result_fields=result_field_names)
+                                           result_fields=result_field_names, experiment_id = experiment_id)
         result_processor._set_name(self.name)
         result_processor._set_machine(socket.gethostname())
 

--- a/py_experimenter/result_processor.py
+++ b/py_experimenter/result_processor.py
@@ -29,7 +29,7 @@ class ResultProcessor:
         self._result_fields = result_fields
         self._config = _config
         self._timestamp_on_result_fields = utils.timestamps_for_result_fields(self._config)
-        self._experiment_id = experiment_id
+        self._experiment_id_condition = f'ID = {experiment_id}'
 
         if _config['PY_EXPERIMENTER']['provider'] == 'sqlite':
             self._dbconnector = DatabaseConnectorLITE(_config)
@@ -54,7 +54,7 @@ class ResultProcessor:
 
         keys = self._dbconnector.escape_sql_chars(*list(results.keys()))
         values = self._dbconnector.escape_sql_chars(*list(results.values()))
-        self._dbconnector._update_database(keys=keys, values=values, where=f'ID = {self._experiment_id}')
+        self._dbconnector._update_database(keys=keys, values=values, where=self._experiment_id_condition)
 
     @staticmethod
     def _add_timestamps_to_results(results: dict, time: datetime) -> List[Tuple[str, object]]:
@@ -69,16 +69,16 @@ class ResultProcessor:
         time = time.strftime("%m/%d/%Y, %H:%M:%S")
 
         if status == 'done' or status == 'error':
-            self._dbconnector._update_database(keys=['status', 'end_date'], values=[status, time], where=f'ID = {self._experiment_id}')
+            self._dbconnector._update_database(keys=['status', 'end_date'], values=[status, time], where=self._experiment_id_condition)
 
     def _write_error(self, error_msg):
-        self._dbconnector._update_database(keys=['error'], values=[error_msg], where=f'ID = {self._experiment_id}')
+        self._dbconnector._update_database(keys=['error'], values=[error_msg], where=self._experiment_id_condition)
 
     def _set_machine(self, machine_id):
-        self._dbconnector._update_database(keys=['machine'], values=[machine_id], where=f'ID = {self._experiment_id}')
+        self._dbconnector._update_database(keys=['machine'], values=[machine_id], where=self._experiment_id_condition)
 
     def _set_name(self, name):
-        self._dbconnector._update_database(keys=['name'], values=[name], where=f'ID = {self._experiment_id}')
+        self._dbconnector._update_database(keys=['name'], values=[name], where=self._experiment_id_condition)
 
     def _valid_result_fields(self, result_fields):
         return set(result_fields).issubset(set(self._result_fields))

--- a/py_experimenter/result_processor.py
+++ b/py_experimenter/result_processor.py
@@ -24,12 +24,12 @@ class ResultProcessor:
     database.
     """
 
-    def __init__(self, _config: dict, credential_path, table_name: str, condition: dict, result_fields: List[str]):
+    def __init__(self, _config: dict, credential_path, table_name: str, result_fields: List[str], experiment_id: int):
         self._table_name = table_name
-        self._where = ' AND '.join([f"{str(key)}='{str(value)}'" for key, value in condition.items()])
         self._result_fields = result_fields
         self._config = _config
         self._timestamp_on_result_fields = utils.timestamps_for_result_fields(self._config)
+        self._experiment_id = experiment_id
 
         if _config['PY_EXPERIMENTER']['provider'] == 'sqlite':
             self._dbconnector = DatabaseConnectorLITE(_config)
@@ -54,7 +54,7 @@ class ResultProcessor:
 
         keys = self._dbconnector.escape_sql_chars(*list(results.keys()))
         values = self._dbconnector.escape_sql_chars(*list(results.values()))
-        self._dbconnector._update_database(keys=keys, values=values, where=self._where)
+        self._dbconnector._update_database(keys=keys, values=values, where=f'ID = {self._experiment_id}')
 
     @staticmethod
     def _add_timestamps_to_results(results: dict, time: datetime) -> List[Tuple[str, object]]:
@@ -69,19 +69,16 @@ class ResultProcessor:
         time = time.strftime("%m/%d/%Y, %H:%M:%S")
 
         if status == 'done' or status == 'error':
-            self._dbconnector._update_database(keys=['status', 'end_date'], values=[status, time], where=self._where)
+            self._dbconnector._update_database(keys=['status', 'end_date'], values=[status, time], where=f'ID = {self._experiment_id}')
 
     def _write_error(self, error_msg):
-        self._dbconnector._update_database(keys=['error'], values=[error_msg], where=self._where)
+        self._dbconnector._update_database(keys=['error'], values=[error_msg], where=f'ID = {self._experiment_id}')
 
     def _set_machine(self, machine_id):
-        self._dbconnector._update_database(keys=['machine'], values=[machine_id], where=self._where)
+        self._dbconnector._update_database(keys=['machine'], values=[machine_id], where=f'ID = {self._experiment_id}')
 
     def _set_name(self, name):
-        self._dbconnector._update_database(keys=['name'], values=[name], where=self._where)
-
-    def _not_executed_yet(self) -> bool:
-        return self._dbconnector.not_executed_yet(where=self._where)
+        self._dbconnector._update_database(keys=['name'], values=[name], where=f'ID = {self._experiment_id}')
 
     def _valid_result_fields(self, result_fields):
         return set(result_fields).issubset(set(self._result_fields))


### PR DESCRIPTION
Instead of checking keyfields the experiment_id is utilized.