### PR TITLE
added files for support for mariadb

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -40,5 +40,5 @@ jobs:
       - name: Run tests
         run: |
           source $VENV
-          # Ignore the MySQL test, as it requires a MySQL server:
-          pytest --ignore=test/test_run_experiments/test_run_mysql_experiment.py --ignore=test/test_logtables/test_mysql.py
+          # Ignore the MySQL and MariaDB tests, as these require running servers:
+          pytest --ignore=test/test_run_experiments/test_run_mysql_experiment.py --ignore=test/test_logtables/test_mysql.py --ignore=test/test_run_experiments/test_run_mariadb_experiment.py --ignore=test/test_logtables/test_mariadb.py

--- a/py_experimenter/database_connector_mariadb.py
+++ b/py_experimenter/database_connector_mariadb.py
@@ -1,0 +1,7 @@
+from configparser import ConfigParser
+from py_experimenter.database_connector_mysql import DatabaseConnectorMYSQL
+
+class DatabaseConnectorMariaDB(DatabaseConnectorMYSQL):
+
+    def __init__(self, experiment_configuration_file_path: ConfigParser, database_credential_file_path):
+        super().__init__(experiment_configuration_file_path, database_credential_file_path, explicit_transactions = False)

--- a/py_experimenter/database_connector_mysql.py
+++ b/py_experimenter/database_connector_mysql.py
@@ -14,11 +14,12 @@ class DatabaseConnectorMYSQL(DatabaseConnector):
     _write_to_database_separator = "', '"
     _prepared_statement_placeholder = '%s'
 
-    def __init__(self, experiment_configuration_file_path: ConfigParser, database_credential_file_path):
+    def __init__(self, experiment_configuration_file_path: ConfigParser, database_credential_file_path, explicit_transactions: bool = True):
         database_credentials = load_config(database_credential_file_path)
         self.host = database_credentials.get('CREDENTIALS', 'host')
         self.user = database_credentials.get('CREDENTIALS', 'user')
         self.password = database_credentials.get('CREDENTIALS', 'password')
+        self.explit_transactions = explicit_transactions
 
         super().__init__(experiment_configuration_file_path)
 
@@ -85,7 +86,8 @@ class DatabaseConnectorMYSQL(DatabaseConnector):
         try:
             connection = self.connect()
             cursor = self.cursor(connection)
-            self._start_transaction(connection, readonly=False)
+            if self.explit_transactions:
+                self._start_transaction(connection, readonly=False)
             experiment_id, description, values = self._execute_queries(connection, cursor)
         except Exception as err:
             connection.rollback()

--- a/py_experimenter/result_processor.py
+++ b/py_experimenter/result_processor.py
@@ -6,6 +6,7 @@ import py_experimenter.utils as utils
 from py_experimenter.database_connector import DatabaseConnector
 from py_experimenter.database_connector_lite import DatabaseConnectorLITE
 from py_experimenter.database_connector_mysql import DatabaseConnectorMYSQL
+from py_experimenter.database_connector_mariadb import DatabaseConnectorMariaDB
 from py_experimenter.exceptions import InvalidConfigError, InvalidResultFieldError
 
 result_logger = logging.getLogger('result_logger')
@@ -37,6 +38,8 @@ class ResultProcessor:
             self._dbconnector: DatabaseConnector = DatabaseConnectorLITE(_config)
         elif _config['PY_EXPERIMENTER']['provider'] == 'mysql':
             self._dbconnector: DatabaseConnector = DatabaseConnectorMYSQL(_config, credential_path)
+        elif _config['PY_EXPERIMENTER']['provider'] == 'mariadb':
+            self._dbconnector: DatabaseConnector = DatabaseConnectorMariaDB(_config, credential_path)
         else:
             raise InvalidConfigError("Invalid database provider!")
 

--- a/test/test_database_connector_mariadb.py
+++ b/test/test_database_connector_mariadb.py
@@ -1,0 +1,31 @@
+from typing import Dict
+
+import pytest
+from py_experimenter.database_connector_mariadb import DatabaseConnectorMariaDB
+
+
+
+@pytest.mark.parametrize(
+    'values, condition, expected',
+    [
+        pytest.param(
+            {'some_key': 'some_value',
+             'some_other_key': 'some_other_value'},
+            'some_condition',
+            'UPDATE some_table SET some_key = %s, some_other_key = %s WHERE some_condition',
+            id='2_values'
+        ),
+        pytest.param(
+            {'some_key': 'some_value'},
+            'some_condition',
+            'UPDATE some_table SET some_key = %s WHERE some_condition',
+            id='1_value'
+        )
+    ]
+)
+def test_prepare_update_query(values: Dict, expected: str, condition: str):
+    class A():
+        _prepared_statement_placeholder = '%s'
+
+    self = A()
+    assert DatabaseConnectorMariaDB._prepare_update_query(self, 'some_table', values,  condition) == expected

--- a/test/test_logtables/mariadb_logtables.cfg
+++ b/test/test_logtables/mariadb_logtables.cfg
@@ -1,0 +1,14 @@
+[PY_EXPERIMENTER]
+provider=mariadb
+database=py_experimenter
+table=test_mariadb_logtables
+n_jobs = 5
+
+keyfields = value:int, exponent:int
+resultfields = sin, cos
+logtables = test_mariadb_log:Log, test_mariadb_log2:Log2
+Log = test:int
+Log2 = test:int
+
+value=1,2,3,4,5,6,7,8,9,10
+exponent=1,2,3

--- a/test/test_logtables/test_mariadb.py
+++ b/test/test_logtables/test_mariadb.py
@@ -1,0 +1,113 @@
+import os
+from configparser import ConfigParser
+from math import cos, sin
+
+from freezegun import freeze_time
+from mock import call, patch
+
+from py_experimenter.database_connector import DatabaseConnector
+from py_experimenter.database_connector_mariadb import DatabaseConnectorMariaDB
+from py_experimenter.experimenter import PyExperimenter
+from py_experimenter.result_processor import ResultProcessor
+
+
+@patch('py_experimenter.experimenter.DatabaseConnectorMYSQL._create_database_if_not_existing')
+@patch('py_experimenter.experimenter.DatabaseConnectorMYSQL._test_connection')
+@patch('py_experimenter.experimenter.DatabaseConnectorMYSQL.fill_table')
+@patch('py_experimenter.experimenter.DatabaseConnectorMYSQL.connect')
+@patch('py_experimenter.experimenter.DatabaseConnectorMYSQL.cursor')
+@patch('py_experimenter.experimenter.DatabaseConnectorMYSQL.fetchall')
+@patch('py_experimenter.experimenter.DatabaseConnectorMYSQL.close_connection')
+@patch('py_experimenter.experimenter.DatabaseConnectorMYSQL.execute')
+def test_tables_created(execute_mock, close_connection_mock, fetchall_mock, cursor_mock, connect_mock, fill_table_mock, test_connection_mock, create_database_mock):
+    execute_mock.return_value = None
+    fetchall_mock.return_value = None
+    close_connection_mock.return_value = None
+    cursor_mock.return_value = None
+    connect_mock.return_value = None
+    fill_table_mock.return_value = None
+    create_database_mock.return_value = None
+    test_connection_mock.return_value = None
+    experimenter = PyExperimenter(os.path.join('test', 'test_logtables', 'mariadb_logtables.cfg'))
+    experimenter.fill_table_from_config()
+    assert execute_mock.mock_calls[1][1][1] == ('CREATE TABLE test_mariadb_logtables (ID INTEGER PRIMARY KEY AUTO_INCREMENT, value int DEFAULT NULL,'
+                                                'exponent int DEFAULT NULL,creation_date DATETIME DEFAULT NULL,status VARCHAR(255) DEFAULT NULL,'
+                                                'start_date DATETIME DEFAULT NULL,name LONGTEXT DEFAULT NULL,machine VARCHAR(255) DEFAULT NULL,'
+                                                'sin VARCHAR(255) DEFAULT NULL,cos VARCHAR(255) DEFAULT NULL,end_date DATETIME DEFAULT NULL,'
+                                                'error LONGTEXT DEFAULT NULL);')
+    print(execute_mock.mock_calls[2][1][1])
+    assert execute_mock.mock_calls[2][1][1] == ('CREATE TABLE test_mariadb_logtables__test_mariadb_log (ID INTEGER PRIMARY KEY AUTO_INCREMENT,'
+                                                ' experiment_id INTEGER, timestamp DATETIME, test int DEFAULT NULL, FOREIGN KEY (experiment_id)'
+                                                ' REFERENCES test_mariadb_logtables(ID) ON DELETE CASCADE);')
+
+
+@freeze_time("2012-01-14 03:21:34")
+@patch('py_experimenter.result_processor.DatabaseConnectorMariaDB')
+def test_logtable_insertion(database_connector_mock):
+    fixed_time = '2012-01-14 03:21:34'
+    config = ConfigParser()
+    config.read(os.path.join('test', 'test_logtables', 'mariadb_logtables.cfg'))
+    result_processor = ResultProcessor(config, None, None, None, 0)
+    result_processor._table_name = 'some_table_name'
+    result_processor.process_logs({'test_table_0': {'test0': 'test', 'test1': 'test'},
+                                   'test_table_1': {'test0': 'test'}})
+    result_processor._dbconnector.execute_queries.assert_called()
+    result_processor._dbconnector.execute_queries.assert_called_with(
+        [f'INSERT INTO some_table_name__test_table_0 (test0, test1, experiment_id, timestamp) VALUES (test, test, 0, \'{fixed_time}\')',
+         f'INSERT INTO some_table_name__test_table_1 (test0, experiment_id, timestamp) VALUES (test, 0, \'{fixed_time}\')'])
+
+
+@patch('py_experimenter.experimenter.DatabaseConnectorMYSQL._create_database_if_not_existing')
+@patch('py_experimenter.experimenter.DatabaseConnectorMYSQL._test_connection')
+@patch('py_experimenter.experimenter.DatabaseConnectorMYSQL.connect')
+@patch('py_experimenter.experimenter.DatabaseConnectorMYSQL.cursor')
+@patch('py_experimenter.experimenter.DatabaseConnectorMYSQL.commit')
+@patch('py_experimenter.experimenter.DatabaseConnectorMYSQL.fetchall')
+@patch('py_experimenter.experimenter.DatabaseConnectorMYSQL.close_connection')
+@patch('py_experimenter.experimenter.DatabaseConnectorMYSQL.execute')
+def test_delete_logtable(execution_mock, close_connection_mock, commit_mocck, fetchall_mock, cursor_mock, connect_mock, test_connection_mock, create_database_mock):
+    fetchall_mock.return_value = cursor_mock.return_value = connect_mock.return_value = commit_mocck.return_value = None
+    close_connection_mock.return_value = test_connection_mock.return_value = create_database_mock.return_value = execution_mock.return_value = None
+    experimenter = PyExperimenter(os.path.join('test', 'test_logtables', 'mariadb_logtables.cfg'))
+    experimenter.delete_table()
+    execution_mock.assert_has_calls([call(None, 'DROP TABLE IF EXISTS test_mariadb_logtables__test_mariadb_log'),
+                                     call(None, 'DROP TABLE IF EXISTS test_mariadb_logtables__test_mariadb_log2'),
+                                     call(None, 'DROP TABLE IF EXISTS test_mariadb_logtables')])
+
+
+# Integration Test
+def own_function(keyfields: dict, result_processor: ResultProcessor, custom_fields: dict):
+    # run the experiment with the given value for the sin and cos function
+    sin_result = sin(keyfields['value'])**keyfields['exponent']
+    cos_result = cos(keyfields['value'])**keyfields['exponent']
+
+    # write result in dict with the resultfield as key
+    result = {'sin': sin_result, 'cos': cos_result}
+
+    # send result to to the database
+    result_processor.process_results(result)
+    result_processor.process_logs({'test_mariadb_log': {'test': 0}, 'test_mariadb_log2': {'test': 1}})
+    result_processor.process_logs({'test_mariadb_log': {'test': 2}, 'test_mariadb_log2': {'test': 3}})
+
+
+def test_integration():
+    experimenter = PyExperimenter(os.path.join('test', 'test_logtables', 'mariadb_logtables.cfg'))
+    try:
+        experimenter.delete_table()
+    except Exception:
+        pass
+    experimenter.fill_table_from_config()
+    experimenter.execute(own_function, 1)
+    connection = experimenter.dbconnector.connect()
+    cursor = experimenter.dbconnector.cursor(connection)
+    cursor.execute(f"SELECT * FROM test_mariadb_logtables__test_mariadb_log")
+    logtable = cursor.fetchall()
+    timesteps = [x[2] for x in logtable]
+    non_timesteps = [x[:2] + x[3:] for x in logtable]
+    assert non_timesteps == [(1, 1, 0), (2, 1, 2)]
+    cursor.execute(f"SELECT * FROM test_mariadb_logtables__test_mariadb_log2")
+    logtable2 = cursor.fetchall()
+    timesteps2 = [x[2] for x in logtable2]
+    logtable2 = [x[:2] + x[3:] for x in logtable2]
+    assert logtable2 == [(1, 1, 1), (2, 1, 3)]
+    assert timesteps == timesteps2

--- a/test/test_run_experiments/test_run_mariadb_error_config.cfg
+++ b/test/test_run_experiments/test_run_mariadb_error_config.cfg
@@ -1,0 +1,9 @@
+[PY_EXPERIMENTER]
+provider=mariadb
+database=py_experimenter
+table=test_mariadb
+n_jobs = 5
+
+keyfields = error_code:NUMERIC
+resultfields = 
+error_code = 0,1,2

--- a/test/test_run_experiments/test_run_mariadb_experiment.py
+++ b/test/test_run_experiments/test_run_mariadb_experiment.py
@@ -1,0 +1,154 @@
+import logging
+import os
+from math import cos, sin
+
+import pandas as pd
+from mysql.connector.errors import ProgrammingError
+
+from py_experimenter.experimenter import PyExperimenter
+from py_experimenter.result_processor import ResultProcessor
+
+
+def own_function(keyfields: dict, result_processor: ResultProcessor, custom_fields: dict):
+    # run the experiment with the given value for the sin and cos function
+    sin_result = sin(keyfields['value'])**keyfields['exponent']
+    cos_result = cos(keyfields['value'])**keyfields['exponent']
+
+    # write result in dict with the resultfield as key
+    result = {'sin': sin_result, 'cos': cos_result}
+
+    # send result to to the database
+    result_processor.process_results(result)
+
+
+def check_done_entries(experimenter, amount_of_entries):
+    connection = experimenter.dbconnector.connect()
+    cursor = experimenter.dbconnector.cursor(connection)
+    cursor.execute(f"SELECT * FROM {experimenter.dbconnector.table_name} WHERE status = 'done'")
+    entries = cursor.fetchall()
+
+    assert amount_of_entries == len(entries)
+
+    experimenter.dbconnector.close_connection(connection)
+
+
+def test_run_all_mqsql_experiments():
+    experiment_configuration_file_path = os.path.join('test', 'test_run_experiments', 'test_run_mariadb_experiment_config.cfg')
+    logging.basicConfig(level=logging.DEBUG)
+    experimenter = PyExperimenter(experiment_configuration_file_path=experiment_configuration_file_path)
+    try:
+        experimenter.delete_table()
+    except ProgrammingError as e:
+        logging.warning(e)
+    experimenter.fill_table_from_config()
+    experimenter.execute(own_function, 1)
+
+    connection = experimenter.dbconnector.connect()
+    cursor = experimenter.dbconnector.cursor(connection)
+    cursor.execute(f"SELECT * FROM {experimenter.dbconnector.table_name} WHERE status = 'done'")
+    entries = cursor.fetchall()
+
+    assert len(entries) == 1
+    entries_without_metadata = entries[0][:3] + (entries[0][4],) + entries[0][6:7] + entries[0][8:10] + (entries[0][-1],)
+    assert entries_without_metadata == (1, 1, 1, 'done', 'PyExperimenter', '0.8414709848078965', '0.5403023058681398', None)
+    experimenter.dbconnector.close_connection(connection)
+
+    experimenter = PyExperimenter(experiment_configuration_file_path=experiment_configuration_file_path)
+    experimenter.fill_table_from_config()
+    experimenter.execute(own_function, -1)
+    check_done_entries(experimenter, 30)
+    connection = experimenter.dbconnector.connect()
+    cursor = experimenter.dbconnector.cursor(connection)
+    cursor.execute(f"DELETE FROM {experimenter.dbconnector.table_name} WHERE ID = 1")
+    experimenter.dbconnector.commit(connection)
+    experimenter.dbconnector.close_connection(connection)
+    check_done_entries(experimenter, 29)
+
+    experimenter.fill_table_from_config()
+    experimenter.execute(own_function, -1)
+    check_done_entries(experimenter, 30)
+    connection = experimenter.dbconnector.connect()
+    cursor = experimenter.dbconnector.cursor(connection)
+    cursor.execute(f"SELECT ID FROM {experimenter.dbconnector.table_name}")
+    entries = cursor.fetchall()
+    experimenter.dbconnector.close_connection(connection)
+
+    assert len(entries) == 30
+    assert set(range(2, 32)) == set(entry[0] for entry in entries)
+
+
+def error_function(keyfields: dict, result_processor: ResultProcessor, custom_fields: dict):
+    raise Exception("Error with weird symbos '@#$%&/\()=")
+
+
+def check_error_entries(experimenter):
+    connection = experimenter.dbconnector.connect()
+    cursor = experimenter.dbconnector.cursor(connection)
+    cursor.execute(f"SELECT * FROM {experimenter.dbconnector.table_name} WHERE status = 'error'")
+    entries = cursor.fetchall()
+    experimenter.dbconnector.close_connection(connection)
+    return entries
+
+
+def test_run_error_experiment():
+    experiment_configuration_file_path = os.path.join('test', 'test_run_experiments', 'test_run_mariadb_experiment_config.cfg')
+    logging.basicConfig(level=logging.DEBUG)
+    experimenter = PyExperimenter(experiment_configuration_file_path=experiment_configuration_file_path)
+    try:
+        experimenter.delete_table()
+    except ProgrammingError as e:
+        logging.warning(e)
+    experimenter.fill_table_from_config()
+    experimenter.execute(error_function, 1)
+
+    entries = check_error_entries(experimenter)
+    assert entries[0][:3] == (1, 1, 1)
+    assert entries[0][4] == 'error'
+    assert entries[0][6] == 'PyExperimenter'
+    assert entries[0][8] == None
+    assert entries[0][9] == None
+    for message in ["in _execution_wrapper", "experiment_function(keyfield_values, result_processor, custom_fields)", "raise Exception(", "Error with weird symbos \'@#$%&/\\()="]:
+        assert message in entries[0][11] 
+
+
+def own_function_raising_errors(keyfields: dict, result_processor: ResultProcessor, custom_fields: dict):
+    error_code = keyfields['error_code']
+
+    # give list of special characters that frequently cause problems
+    characters = ['"', "'", '@', '#', '$', '%', '&', '/', '\\', '(', ')', '=', "`", "`some_text`", "^"]
+    if error_code == 0:
+        raise Exception("Error with weird symbos" + "".join(characters))
+    elif error_code == 1:
+        raise LookupError("Error with weird symbos" + "".join(characters))
+    elif error_code == 2:
+        raise ProgrammingError("Error with weird symbos" + "".join(characters))
+
+
+def test_raising_error_experiment():
+    experimenter = PyExperimenter(experiment_configuration_file_path=os.path.join('test', 'test_run_experiments', 'test_run_mariadb_error_config.cfg'),
+                                  name='name')
+
+    try:
+        experimenter.delete_table()
+    except ProgrammingError as e:
+        logging.warning(e)
+
+    experimenter.fill_table_from_config()
+    experimenter.execute(own_function_raising_errors, -1)
+    table = experimenter.get_table()
+    'lala'
+    table = table[['ID', 'error_code', 'status', 'name']]
+    pd.testing.assert_frame_equal(
+        table,
+        pd.DataFrame(
+            {
+                'ID': [1, 2, 3],
+                'error_code': [0., 1., 2.],
+                'status': ['error', 'error', 'error'],
+                'name': ['name', 'name', 'name'],
+            }
+        )
+    )
+
+    
+    

--- a/test/test_run_experiments/test_run_mariadb_experiment_config.cfg
+++ b/test/test_run_experiments/test_run_mariadb_experiment_config.cfg
@@ -1,0 +1,11 @@
+[PY_EXPERIMENTER]
+provider=mariadb
+database=py_experimenter
+table=test_mariadb
+n_jobs = 5
+
+keyfields = value:int, exponent:int
+resultfields = sin, cos
+
+value=1,2,3,4,5,6,7,8,9,10
+exponent=1,2,3


### PR DESCRIPTION
Adding support for a new driver in the config file, namely `mariadb`. At this moment, this is equivalent to MySQL except that transactions are not declared explicitly.