### PR TITLE
Hotfix for running on clusters.

### DIFF
--- a/py_experimenter/database_connector.py
+++ b/py_experimenter/database_connector.py
@@ -208,26 +208,35 @@ class DatabaseConnector(abc.ABC):
             raise DatabaseConnectionError(f'error \n {e} raised. \n Please check if fill_table() was called correctly.')
 
         return experiment_id, dict(zip([i[0] for i in description], *values))
-    
+
     @abc.abstractmethod
     def _pull_open_experiment(self) -> Tuple[int, List, List]:
         pass
 
     def _select_open_experiments_from_db(self, connection, cursor) -> Tuple[int, List, List]:
-        order_by = "id"
+        cursor = self.cursor(connection)
         time = utils.get_timestamp_representation()
 
-        self.execute(cursor, f"SELECT id FROM {self.table_name} WHERE status = 'created' ORDER BY {order_by} LIMIT 1;")
-        experiment_id = self.fetchall(cursor)[0][0]
+        self.execute(cursor, self._get_pull_experiment_query(order_by="id"))
+        results = self.fetchall(cursor)
+        experiment_id = results[0][0]
         self.execute(
             cursor, f"UPDATE {self.table_name} SET status = {self._prepared_statement_placeholder}, start_date = {self._prepared_statement_placeholder} WHERE id = {self._prepared_statement_placeholder};", (ExperimentStatus.RUNNING.value, time, experiment_id))
+        self.commit(connection)
+        cursor.close()
+
+        cursor = self.cursor(connection)
         keyfields = ','.join(utils.get_keyfield_names(self.config))
         self.execute(cursor, f"SELECT {keyfields} FROM {self.table_name} WHERE id = {experiment_id};")
         values = self.fetchall(cursor)
-        self.commit(connection)
         description = cursor.description
+        cursor.close()
+
         return experiment_id, description, values
 
+    @abc.abstractmethod
+    def _get_pull_experiment_query(self, order_by: str):
+        return f"SELECT `id` FROM {self.table_name} WHERE status = 'created' ORDER BY {order_by} LIMIT 1"
 
     def _write_to_database(self, values: List, columns=List[str]) -> None:
         values_prepared = ','.join([f"({', '.join([self._prepared_statement_placeholder] * len(columns))})"] * len(values))
@@ -335,7 +344,7 @@ class DatabaseConnector(abc.ABC):
     def get_table(self, table_name: Optional[str] = None) -> pd.DataFrame:
         connection = self.connect()
         query = f"SELECT * FROM {self.table_name}" if table_name is None else f"SELECT * FROM {table_name}"
-        #suppress warning for pandas
+        # suppress warning for pandas
         import warnings
         with warnings.catch_warnings():
             warnings.filterwarnings("ignore", category=UserWarning)

--- a/py_experimenter/database_connector_lite.py
+++ b/py_experimenter/database_connector_lite.py
@@ -41,6 +41,9 @@ class DatabaseConnectorLITE(DatabaseConnector):
 
         return experiment_id, description, values
 
+    def _get_pull_experiment_query(self, order_by):
+        return super()._get_pull_experiment_query(order_by) + ';'
+
     def _table_exists(self, cursor) -> bool:
         self.execute(cursor, f"SELECT name FROM sqlite_master WHERE type='table';")
         table_names = self.fetchall(cursor)

--- a/py_experimenter/database_connector_mysql.py
+++ b/py_experimenter/database_connector_mysql.py
@@ -13,7 +13,7 @@ from py_experimenter.utils import load_config
 class DatabaseConnectorMYSQL(DatabaseConnector):
     _prepared_statement_placeholder = '%s'
 
-    def __init__(self, experiment_configuration: ConfigParser, use_codecarbon:bool, codecarbon_config:ConfigParser, database_credential_file_path:str, logger):
+    def __init__(self, experiment_configuration: ConfigParser, use_codecarbon: bool, codecarbon_config: ConfigParser, database_credential_file_path: str, logger):
         database_credentials = load_config(database_credential_file_path)
         self.host = database_credentials.get('CREDENTIALS', 'host')
         self.user = database_credentials.get('CREDENTIALS', 'user')
@@ -65,7 +65,7 @@ class DatabaseConnectorMYSQL(DatabaseConnector):
         if not readonly:
             connection.begin()
 
-    def _table_exists(self, cursor, table_name:str = None) -> bool:
+    def _table_exists(self, cursor, table_name: str = None) -> bool:
         table_name = table_name if table_name is not None else self.table_name
         self.execute(cursor, f"SHOW TABLES LIKE '{table_name}'")
         return self.fetchall(cursor)
@@ -81,7 +81,7 @@ class DatabaseConnectorMYSQL(DatabaseConnector):
 
         columns = self._exclude_fixed_columns([k[0] for k in self.fetchall(cursor)])
         config_columns = [k[0] for k in typed_fields]
-        return set(columns) == set(config_columns) 
+        return set(columns) == set(config_columns)
 
     def _pull_open_experiment(self) -> Tuple[int, List, List]:
         try:
@@ -89,13 +89,17 @@ class DatabaseConnectorMYSQL(DatabaseConnector):
             cursor = self.cursor(connection)
             self._start_transaction(connection, readonly=False)
             experiment_id, description, values = self._select_open_experiments_from_db(connection, cursor)
-        except Exception as err:
+        except Exception as e:
             connection.rollback()
-            raise err
-        self.close_connection(connection)
+            raise e
+        finally:
+            self.close_connection(connection)
 
         return experiment_id, description, values
-    
+
+    def _get_pull_experiment_query(self, order_by: str):
+        return super()._get_pull_experiment_query(order_by) + " FOR UPDATE;"
+
     def _get_existing_rows(self, column_names):
         def _remove_double_whitespaces(existing_rows):
             return [' '.join(row.split()) for row in existing_rows]
@@ -119,4 +123,3 @@ class DatabaseConnectorMYSQL(DatabaseConnector):
         self.execute(cursor, f"SHOW COLUMNS FROM {self.table_name}")
         column_names = _get_column_names_from_entries(self.fetchall(cursor))
         return column_names
-    


### PR DESCRIPTION
Previously multiple runners pulled the same experiment_id. This should be fixed now.

<!--- Provide a general summary of your changes in the title above. -->

## Description
<!--- Provide a short description of your changes. -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Changes
<!--- Explain your changes in detail here. -->

#### Type Of Changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## How has This Been Tested?

- Database provider: mysql (sqlite only touched because of abstract class)
- Python version: 3.9.12
- Operating System: ubuntu 20.4

Tests are not possible, since this issue deals with locking experiments

## Does this Close/Impact Existing Issues?
No

## What is Missing?
The mentioned merge request help, but does not fully solve the problem.

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My change is based on the latest stage of the `develop` branch.
- [ ] My change required a change of the documentation, which has been done.
- [x] I checked that the documentation can be build, visualizes everything as expected, and does not contain any warnings.
- [ ] I have added/adapted tests to cover my changes.
- [x] The tests can be executed successfully.
- [x] The notebooks can be executed successfully.
- [x] The notebooks can be executed with `mysql` as provider.
- [ ] I have added a description of the changes to `CHANGELOG.rst`.
