### PR TITLE
Hotfix cluster execution fix

### DIFF
--- a/py_experimenter/database_connector.py
+++ b/py_experimenter/database_connector.py
@@ -209,6 +209,7 @@ class DatabaseConnector(abc.ABC):
 
         return experiment_id, dict(zip([i[0] for i in description], *values))
 
+
     @abc.abstractmethod
     def _pull_open_experiment(self, random_order) -> Tuple[int, List, List]:
         pass
@@ -220,20 +221,30 @@ class DatabaseConnector(abc.ABC):
             order_by = "id"
         time = utils.get_timestamp_representation()
 
-        self.execute(cursor, f"SELECT id FROM {self.table_name} WHERE status = 'created' ORDER BY {order_by} LIMIT 1;")
-        experiment_id = self.fetchall(cursor)[0][0]
+        self.execute(cursor, self._get_pull_experiment_query(order_by="id"))
+        results = self.fetchall(cursor)
+        experiment_id = results[0][0]
         self.execute(
             cursor, f"UPDATE {self.table_name} SET status = {self._prepared_statement_placeholder}, start_date = {self._prepared_statement_placeholder} WHERE id = {self._prepared_statement_placeholder};", (ExperimentStatus.RUNNING.value, time, experiment_id))
+        self.commit(connection)
+        cursor.close()
+
+        cursor = self.cursor(connection)
         keyfields = ','.join(utils.get_keyfield_names(self.config))
         self.execute(cursor, f"SELECT {keyfields} FROM {self.table_name} WHERE id = {experiment_id};")
         values = self.fetchall(cursor)
-        self.commit(connection)
         description = cursor.description
+        cursor.close()
+
         return experiment_id, description, values
 
     @abc.abstractstaticmethod
     def random_order_string():
         pass
+    
+    @abc.abstractmethod
+    def _get_pull_experiment_query(self, order_by: str):
+        return f"SELECT `id` FROM {self.table_name} WHERE status = 'created' ORDER BY {order_by} LIMIT 1"
 
     def _write_to_database(self, values: List, columns=List[str]) -> None:
         values_prepared = ','.join([f"({', '.join([self._prepared_statement_placeholder] * len(columns))})"] * len(values))

--- a/py_experimenter/database_connector_lite.py
+++ b/py_experimenter/database_connector_lite.py
@@ -41,6 +41,9 @@ class DatabaseConnectorLITE(DatabaseConnector):
 
         return experiment_id, description, values
 
+    def _get_pull_experiment_query(self, order_by):
+        return super()._get_pull_experiment_query(order_by) + ';'
+
     def _table_exists(self, cursor) -> bool:
         self.execute(cursor, f"SELECT name FROM sqlite_master WHERE type='table';")
         table_names = self.fetchall(cursor)

--- a/py_experimenter/database_connector_mysql.py
+++ b/py_experimenter/database_connector_mysql.py
@@ -91,7 +91,7 @@ class DatabaseConnectorMYSQL(DatabaseConnector):
             experiment_id, description, values = self._select_open_experiments_from_db(connection, cursor, random_order=random_order)
         except Exception as err:
             connection.rollback()
-            raise e
+            raise err
         finally:
             self.close_connection(connection)
 

--- a/py_experimenter/database_connector_mysql.py
+++ b/py_experimenter/database_connector_mysql.py
@@ -91,11 +91,15 @@ class DatabaseConnectorMYSQL(DatabaseConnector):
             experiment_id, description, values = self._select_open_experiments_from_db(connection, cursor, random_order=random_order)
         except Exception as err:
             connection.rollback()
-            raise err
-        self.close_connection(connection)
+            raise e
+        finally:
+            self.close_connection(connection)
 
         return experiment_id, description, values
 
+    def _get_pull_experiment_query(self, order_by: str):
+        return super()._get_pull_experiment_query(order_by) + " FOR UPDATE;"
+    
     @staticmethod
     def random_order_string():
         return 'RAND()'


### PR DESCRIPTION
Previously multiple runners pulled the same experiment_id. This should be fixed now.

<!--- Provide a general summary of your changes in the title above. -->

## Description
<!--- Provide a short description of your changes. -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Changes
<!--- Explain your changes in detail here. -->

#### Type Of Changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## How has This Been Tested?

- Database provider: mysql (sqlite only touched because of abstract class)
- Python version: 3.9.12
- Operating System: ubuntu 20.4

Tests are not possible, since this issue deals with locking experiments

## Does this Close/Impact Existing Issues?
No

## What is Missing?
The mentioned merge request help, but does not fully solve the problem.

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My change is based on the latest stage of the `develop` branch.
- [ ] My change required a change of the documentation, which has been done.
- [x] I checked that the documentation can be build, visualizes everything as expected, and does not contain any warnings.
- [ ] I have added/adapted tests to cover my changes.
- [x] The tests can be executed successfully.
- [x] The notebooks can be executed successfully.
- [x] The notebooks can be executed with `mysql` as provider.
- [ ] I have added a description of the changes to `CHANGELOG.rst`.
