### PR TITLE
Fix the problem when executing fill_table twice

### DIFF
--- a/py_experimenter/database_connector.py
+++ b/py_experimenter/database_connector.py
@@ -118,13 +118,15 @@ class DatabaseConnector(abc.ABC):
                 )
 
     def _exclude_fixed_columns(self, columns: List[str]) -> List[str]:
-        amount_of_keyfields = len(utils.get_keyfield_names(self.config))
-        amount_of_result_fields = len(utils.get_result_field_names(self.config))
-
-        if self.timestamp_on_result_fields:
-            amount_of_result_fields *= 2
-
-        return columns[1:amount_of_keyfields + 1] + columns[-amount_of_result_fields - 2:-2]
+        columns.remove('ID')
+        columns.remove('status')
+        columns.remove('creation_date')
+        columns.remove('start_date')
+        columns.remove('name')
+        columns.remove('machine')
+        columns.remove('end_date')
+        columns.remove('error')
+        return columns
 
     def _create_table(self, cursor, columns: List[Tuple['str']], table_name: str, table_type: str = 'standard'):
         query = self._get_create_table_query(columns, table_name, table_type)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

## Description
<!--- Provide a short description of your changes. -->
Fix issue form mentioned issue
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Newer versions of mysql return table columns sorted alphabetically. Our previous codebases hardcoded checking whether the structure was correct, which does not work anymore.
## Changes
<!--- Explain your changes in detail here. -->
Decide flexibly whether or not a table is of correct structure
#### Type Of Changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## How has This Been Tested?

- Database provider: mysql
- Python version:  Any
- Operating System: Any

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Instead of selecting relevant columns from the datbase to compare, all irrelevant coluns (such as start date) are deleted before comparing

## Does this Close/Impact Existing Issues?
<!--- Please link to all relevant issues. -->
- Issue #167 

## What is Missing?
<!--- Please provide any further information that is needed to close this PR. -->
<!--- This could be another PR that is blocking this PR, or any further changes -->
<!--- that need to be addressed in the future. -->
Nothin

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My change is based on the latest stage of the `develop` branch.
- [ ] My change required a change of the documentation, which has been done.
- [x] I checked that the documentation can be build, visualizes everything as expected, and does not contain any warnings.
- [x] I have added/adapted tests to cover my changes.
- [x] The tests can be executed successfully.
- [x] The notebooks can be executed successfully.
- [x] The notebooks can be executed with `mysql` as provider.
- [x] I have added a description of the changes to `CHANGELOG.rst`.
