### PR TITLE
Bugfix of ssh passphrase

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -16,6 +16,7 @@ Fix
 
 - Booleans have been added as strings to the database table in SQLite. This has been fixed by adding a converting the values accordingly before writing them to the database.
 - Bugfix, where the same experiment has been pulled multiple times when using `n_jobs` > 1.
+- Bugfix where the ssh passphrase was not correctly addressed in the documentation, and not been used correctly in the code.
 
 
 v1.4.0 (20.02.2024)

--- a/docs/source/usage/database_credential_file.rst
+++ b/docs/source/usage/database_credential_file.rst
@@ -35,7 +35,7 @@ The following example shows how to connect to a database server using an SSH ser
           server: example.mysqlserver.com (address from ssh server)
           address: ssh_hostname (either name/ip address of the ssh server or a name from you local ssh config file)
           port: optional_ssh_port (default: 22)
-          passphrase: passphrase
+          ssh_private_key_password: passphrase
           remote_address: optional_mysql_server_address (default: 127.0.0.1)
           remote_port: optional_mysql_server_port (default: 3306)
           local_address: optional_local_address (default: 127.0.0.1)

--- a/py_experimenter/database_connector_mysql.py
+++ b/py_experimenter/database_connector_mysql.py
@@ -31,7 +31,7 @@ class DatabaseConnectorMYSQL(DatabaseConnector):
             parameters = dict(credentials["Ssh"])
             ssh_address_or_host = parameters["address"]
             ssh_address_or_host_port = parameters["port"] if "port" in parameters else 22
-            ssh_keypass = parameters["ssh_keypass"] if "ssh_keypass" in parameters else None
+            ssh_private_key_password = parameters["ssh_private_key_password"] if "ssh_private_key_password" in parameters else None
             remote_bind_address = parameters["remote_address"] if "remote_address" in parameters else "127.0.0.1"
             remote_bind_address_port = parameters["remote_port"] if "remote_port" in parameters else 3306
             local_bind_address = parameters["local_address"] if "local_address" in parameters else "127.0.0.1"
@@ -40,7 +40,7 @@ class DatabaseConnectorMYSQL(DatabaseConnector):
             try:
                 tunnel = sshtunnel.SSHTunnelForwarder(
                     ssh_address_or_host=(ssh_address_or_host, ssh_address_or_host_port),
-                    ssh_pkey=ssh_keypass,
+                    ssh_private_key_password=ssh_private_key_password,
                     remote_bind_address=(remote_bind_address, remote_bind_address_port),
                     local_bind_address=(local_bind_address, local_bind_address_port),
                     logger=logger,

--- a/py_experimenter/experimenter.py
+++ b/py_experimenter/experimenter.py
@@ -296,8 +296,12 @@ class PyExperimenter:
         :param experiment_function: _description_ The experiment function to use to continue the given experiment
         :type experiment_function: Callable
         """
+        self._write_codecarbon_config()
+
         keyfield_dict, _ = self.db_connector.pull_paused_experiment(experiment_id)
         self._execute_experiment(experiment_id, keyfield_dict, experiment_function)
+
+        self._delete_codecarbon_config()
 
     def _worker(self, experiment_function: Callable[[Dict, Dict, ResultProcessor], None], random_order: bool) -> None:
         """

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "py-experimenter"
-version = "1.4.1a3"
+version = "1.4.1a4"
 description = "The PyExperimenter is a tool for the automatic execution of experiments, e.g. for machine learning (ML), capturing corresponding results in a unified manner in a database."
 authors = [
     "Tanja Tornede <t.tornede@ai.uni-hannover.de>",


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

## Description
<!--- Provide a short description of your changes. -->
There was a slight mistake in the ssh documentation.
We wrongly provide `sshtunnel` with the `pkey` parameter instead of `ssh_private_key_password`

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Changes
<!--- Explain your changes in detail here. -->

#### Type Of Changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## How has This Been Tested?

- Database provider:
- Python version:
- Operating System:

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Does this Close/Impact Existing Issues?
<!--- Please link to all relevant issues. -->
- Issue #178 

## What is Missing?
<!--- Please provide any further information that is needed to close this PR. -->
<!--- This could be another PR that is blocking this PR, or any further changes -->
<!--- that need to be addressed in the future. -->

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My change is based on the latest stage of the `develop` branch.
- [x] My change required a change of the documentation, which has been done.
- [x] I checked that the documentation can be build, visualizes everything as expected, and does not contain any warnings.
- [ ] I have added/adapted tests to cover my changes.
- [ ] The tests can be executed successfully.
- [x] The notebooks can be executed successfully.
- [ ] The notebooks can be executed with `mysql` as provider.
- [x] I have added a description of the changes to `CHANGELOG.rst`.
