### PR TITLE
187 incorrect docstring behaviour for use ssh tunnel

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -62,4 +62,10 @@
 	"[python]": {
 		"editor.defaultFormatter": "ms-python.black-formatter"
 	},
+	"grammarly.selectors": [
+		{
+			"language": "restructuredtext",
+			"scheme": "file"
+		}
+	],
 }

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -20,6 +20,7 @@ Feature
 - Added logging whenever a sql statement is executed.
 - Update CI such that the tests are run on Python 3.9 and 3.10, additionally removed the paper draft action. 
 - Added logging when initializing database to contain resultfields and logfields.
+- Adapt ssh tunnel usage to be more flexible and user friendly.
 
 Fix
 ---

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -10,6 +10,13 @@ Feature
 -------
 
 - Added documentation about how to execute PyExperimenter on distributed machines.
+- Improved the usage and documentation of ssh tunnel to be more flexible and user friendly.
+
+Fix
+---
+
+
+
 
 v1.4.1 (11.03.2024)
 ===================
@@ -20,7 +27,6 @@ Feature
 - Added logging whenever a sql statement is executed.
 - Update CI such that the tests are run on Python 3.9 and 3.10, additionally removed the paper draft action. 
 - Added logging when initializing database to contain resultfields and logfields.
-- Adapt ssh tunnel usage to be more flexible and user friendly.
 
 Fix
 ---

--- a/docs/source/usage/database_credential_file.rst
+++ b/docs/source/usage/database_credential_file.rst
@@ -19,7 +19,7 @@ Below is an example of a database credential file, that connects to a server wit
           server: example.mysqlserver.com
 
 However, for security reasons, databases might only be accessible from a specific IP address. In these cases, one can use an ssh jumphost. This means that ``PyExperimenter`` will first connect to the ssh server
-that has access to the database and then connect to the database server from there. This is done by adding an additional ``Ssh`` section to the database credential file, and can be activated either by a PyExperimenter keyword argument or in the :ref:`experimenter configuration file <_experiment_configuration_file>`.
+that has access to the database and then connect to the database server from there. This is done by adding an additional ``Ssh`` section to the database credential file, and can be activated either by a ``PyExperimenter`` keyword argument or in the :ref:`experimenter configuration file <_experiment_configuration_file>`.
 The following example shows how to connect to a database server using an SSH server with the address ``ssh_hostname`` and the port ``optional_ssh_port``.
 
 .. code-block:: yaml

--- a/docs/source/usage/database_credential_file.rst
+++ b/docs/source/usage/database_credential_file.rst
@@ -19,7 +19,7 @@ Below is an example of a database credential file, that connects to a server wit
           server: example.mysqlserver.com
 
 However, for security reasons, databases might only be accessible from a specific IP address. In these cases, one can use an ssh jumphost. This means that ``PyExperimenter`` will first connect to the ssh server
-that has access to the database and then connect to the database server from there. This is done by adding an additional ``Ssh`` section to the database credential file.
+that has access to the database and then connect to the database server from there. This is done by adding an additional ``Ssh`` section to the database credential file, and can be activated either by a PyExperimenter keyword argument or in the :ref:`experimenter configuration file <_experiment_configuration_file>`.
 The following example shows how to connect to a database server using an SSH server with the address ``ssh_hostname`` and the port ``optional_ssh_port``.
 
 .. code-block:: yaml

--- a/docs/source/usage/experiment_configuration_file.rst
+++ b/docs/source/usage/experiment_configuration_file.rst
@@ -14,7 +14,7 @@ The experiment configuration file is primarily used to define the database backe
       Database:
         provider: sqlite
         database: py_experimenter
-        use_ssh_tunnel: False             (Optional Parameter; Defautls to False)
+        use_ssh_tunnel: False
         table: 
           name: example_general_usage
           keyfields:
@@ -70,6 +70,7 @@ The ``Database`` section defines the database and its structure.
 
 - ``provider``: The provider of the database connection. Currently, ``sqlite`` and ``mysql`` are supported. In the case of ``mysql`` an additional :ref:`database credential file <database_credential_file>` has to be created.
 - ``database``: The name of the database to create or connect to.
+- ``use_ssh_tunnel``: Flag to decide if the database is connected via ssh as defined in the :ref:`database credential file <database_credential_file>`. This is ignored if ``sqlite`` is chosen as provider. Optional Parameter, default is False.
 - ``table``: Defines the structure and predefined values for the experiment table. 
 
     - ``name``: The name of the experiment table to create or connect to.

--- a/docs/source/usage/experiment_configuration_file.rst
+++ b/docs/source/usage/experiment_configuration_file.rst
@@ -14,6 +14,7 @@ The experiment configuration file is primarily used to define the database backe
       Database:
         provider: sqlite
         database: py_experimenter
+        use_ssh_tunnel: False             (Optional Parameter; Defautls to False)
         table: 
           name: example_general_usage
           keyfields:

--- a/py_experimenter/experimenter.py
+++ b/py_experimenter/experimenter.py
@@ -29,7 +29,7 @@ class PyExperimenter:
         self,
         experiment_configuration_file_path: str = os.path.join("config", "experiment_configuration.yml"),
         database_credential_file_path: str = os.path.join("config", "database_credentials.yml"),
-        use_ssh_tunnel: bool = False,
+        use_ssh_tunnel: Optional[bool] = None,
         table_name: str = None,
         database_name: str = None,
         use_codecarbon: bool = True,
@@ -49,9 +49,11 @@ class PyExperimenter:
             for the database connection, i.e., host, user and password. Defaults to 'config/database_credentials.cfg'.
         :type database_credential_file_path: str, optional
         :param use_ssh_tunnel: If the used database is sqlite this parameter is ignored. Otherwise: If the database is mysql,
-            and `use_ssh_tunnel == True` the ssh credentials provided in `database_credential_file_path` are used to establish
+            and `use_ssh_tunnel == None` the ssh decision is based on the configuration file (defaults to false).
+            If `use_ssh_tunnel != True` the ssh credentials provided in `database_credential_file_path` are used to establish
             an ssh tunnel to the database. If `use_ssh_tunnel == True` but no ssh credentials are provided in
-            `database_credential_file_path`, an error is raised. Defaults to True.
+            `database_credential_file_path`, an error is raised. If `use_shh_tunnel==False` PxExperimenter directly connects
+            to the databse. Defaults to None.
         :type use_ssh_tunnel: bool
         :param table_name: The name of the database table, if given it will overwrite the table_name given in the
             `experiment_configuration_file_path`. If None, the table table name is taken from the experiment

--- a/py_experimenter/experimenter.py
+++ b/py_experimenter/experimenter.py
@@ -12,10 +12,7 @@ from py_experimenter import utils
 from py_experimenter.config import PyExperimenterCfg
 from py_experimenter.database_connector_lite import DatabaseConnectorLITE
 from py_experimenter.database_connector_mysql import DatabaseConnectorMYSQL
-from py_experimenter.exceptions import (
-    InvalidConfigError,
-    NoExperimentsLeftException,
-)
+from py_experimenter.exceptions import InvalidConfigError, NoExperimentsLeftException
 from py_experimenter.experiment_status import ExperimentStatus
 from py_experimenter.result_processor import ResultProcessor
 
@@ -107,7 +104,10 @@ class PyExperimenter:
             raise InvalidConfigError("Invalid configuration")
 
         self.database_credential_file_path = database_credential_file_path
-        self.use_ssh_tunnel = use_ssh_tunnel
+
+        # If use_ssh_tunnel is not None, the decision is based on the given kwarg
+        if use_ssh_tunnel is not None:
+            self.config.database_configuration.use_ssh_tunnel = use_ssh_tunnel
 
         if table_name is not None:
             self.config.database_configuration.table_name = table_name
@@ -121,7 +121,7 @@ class PyExperimenter:
             self.db_connector = DatabaseConnectorLITE(self.config.database_configuration, self.use_codecarbon, self.logger)
         elif self.config.database_configuration.provider == "mysql":
             self.db_connector = DatabaseConnectorMYSQL(
-                self.config.database_configuration, self.use_codecarbon, database_credential_file_path, use_ssh_tunnel, self.logger
+                self.config.database_configuration, self.use_codecarbon, database_credential_file_path, self.logger
             )
         else:
             raise ValueError("The provider indicated in the config file is not supported")
@@ -132,7 +132,7 @@ class PyExperimenter:
         """
         Closes the ssh tunnel if it is used.
         """
-        if self.config.database_configuration.provider == "mysql" and self.use_ssh_tunnel:
+        if self.config.database_configuration.provider == "mysql":
             self.db_connector.close_ssh_tunnel()
         else:
             self.logger.warning("No ssh tunnel to close")

--- a/py_experimenter/experimenter.py
+++ b/py_experimenter/experimenter.py
@@ -48,10 +48,10 @@ class PyExperimenter:
         :param database_credential_file_path: The path to the database configuration file storing the credentials
             for the database connection, i.e., host, user and password. Defaults to 'config/database_credentials.cfg'.
         :type database_credential_file_path: str, optional
-        :param use_ssh_tunnel: If the used dataabse is sqlite this parameter is ignored Otherwise: If the database is mysql,
-            and `use_ssh_tunnel == True` the ssh credentials provided in `database_credential_file_path` used to establish
-            a ssh tunnel to the database. If `use_ssh_tunnel == True` but no ssh credentials are provided in
-            `database_credential_file_path`, no ssh tunnel is established. Defaults to True.
+        :param use_ssh_tunnel: If the used database is sqlite this parameter is ignored. Otherwise: If the database is mysql,
+            and `use_ssh_tunnel == True` the ssh credentials provided in `database_credential_file_path` are used to establish
+            an ssh tunnel to the database. If `use_ssh_tunnel == True` but no ssh credentials are provided in
+            `database_credential_file_path`, an error is raised. Defaults to True.
         :type use_ssh_tunnel: bool
         :param table_name: The name of the database table, if given it will overwrite the table_name given in the
             `experiment_configuration_file_path`. If None, the table table name is taken from the experiment
@@ -74,6 +74,7 @@ class PyExperimenter:
         :type log_file: str
         :raises InvalidConfigError: If either the experiment or database configuration are missing mandatory information.
         :raises ValueError: If an unsupported or unknown database connection provider is given.
+        :raises SshTunnelError: If the ssh tunnel could not be established, or if the ssh credentials are missing/invalid.
         """
         # If the logger is not allready craeted, create it with the given name and level
         self.logger_name = logger_name

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "py-experimenter"
-version = "1.4.2a0"
+version = "1.4.2a1"
 description = "The PyExperimenter is a tool for the automatic execution of experiments, e.g. for machine learning (ML), capturing corresponding results in a unified manner in a database."
 authors = [
     "Tanja Tornede <t.tornede@ai.uni-hannover.de>",

--- a/test/test_database_connector.py
+++ b/test/test_database_connector.py
@@ -133,7 +133,6 @@ def test_fill_table(
         experiment_configuration,
         False,
         CREDENTIAL_PATH,
-        False,
         logger=logger,
     )
 
@@ -176,7 +175,7 @@ def test_delete_experiments_with_condition(
 
     config = OmegaConf.load(CONFIG_PATH)
     experiment_configuration = DatabaseCfg.extract_config(config, logger)
-    database_connector = DatabaseConnectorMYSQL(experiment_configuration, False, CREDENTIAL_PATH, use_ssh_tunnel=True, logger=logger)
+    database_connector = DatabaseConnectorMYSQL(experiment_configuration, False, CREDENTIAL_PATH, logger=logger)
 
     database_connector._delete_experiments_with_condition(f'WHERE status = "{ExperimentStatus.CREATED.value}"')
 
@@ -222,7 +221,7 @@ def test_get_experiments_with_condition(
 
     config = OmegaConf.load(CONFIG_PATH)
     experiment_configuration = DatabaseCfg.extract_config(config, logger)
-    database_connector = DatabaseConnectorMYSQL(experiment_configuration, False, CREDENTIAL_PATH, False, logger=logger)
+    database_connector = DatabaseConnectorMYSQL(experiment_configuration, False, CREDENTIAL_PATH, logger=logger)
 
     database_connector._get_experiments_with_condition(f'WHERE status = "{ExperimentStatus.CREATED.value}"')
 
@@ -251,7 +250,7 @@ def test_delete_table(
 
     config = OmegaConf.load(CONFIG_PATH)
     experiment_configuration = DatabaseCfg.extract_config(config, logger)
-    database_connector = DatabaseConnectorMYSQL(experiment_configuration, False, CREDENTIAL_PATH, False, logger=logger)
+    database_connector = DatabaseConnectorMYSQL(experiment_configuration, False, CREDENTIAL_PATH, logger=logger)
 
     database_connector.delete_table()
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

## Description
<!--- Provide a short description of your changes. -->
Update of both the documentation and behavior of ssh-tunnel


## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
The documentation contained typos, and the code behaved unintuitively.

## Changes
<!--- Explain your changes in detail here. -->
Now there are three possible ways to configure the experiment
1. Highest Precedence: The value given to the experimenter as a kwarg
2. Middle Precedence: The config file
3. Lowest Precedence: Default Value

#### Type Of Changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## How has This Been Tested?

- Database provider: Mysql and SQLITe
- Python version: 3.9
- Operating System: Linux Ubuntu

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Does this Close/Impact Existing Issues?
<!--- Please link to all relevant issues. -->
- Issue #187 

## What is Missing?
<!--- Please provide any further information that is needed to close this PR. -->
<!--- This could be another PR that is blocking this PR, or any further changes -->
<!--- that need to be addressed in the future. -->

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My change is based on the latest stage of the `develop` branch.
- [x] My change required a change of the documentation, which has been done.
- [x] I checked that the documentation can be build, visualizes everything as expected, and does not contain any warnings.
- [x] I have added/adapted tests to cover my changes.
- [x] The tests can be executed successfully.
- [x] The notebooks can be executed successfully.
- [x] The notebooks can be executed with `mysql` as provider.
- [x] I have added a description of the changes to `CHANGELOG.rst`.
